### PR TITLE
Fixed sass-error-handling and added babel.js an es6 transpiler

### DIFF
--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -17,7 +17,8 @@ gulp.task('scripts', function() {
         .pipe($.size({ title: 'vendor scripts done.' }));
 
     var app = gulp.src(build.files.scripts.map(function (file) { return paths.scripts.src + '/' + file; }))
-        .pipe($.jshint())
+        .pipe($.jshint({ 'esnext' : true }))
+        .pipe($.babel())
         .pipe($.notify(function (file) {
 
             // don't show something if success

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -5,10 +5,9 @@ gulp.task('styles', function() {
 
     var app = gulp.src(build.files.styles.map(function (file) { return paths.styles.src + '/' + file; }))
         .pipe($.sass({
-            errLogToConsole: true,
             indentedSyntax: true,
             outputStyle: sassStyle
-        }))
+        }).on('error', $.sass.logError))
         // @see https://github.com/ai/autoprefixer
         .pipe($.autoprefixer(build.autoprefixer && build.autoprefixer.browsers ? build.autoprefixer.browsers : 'last 2 versions'));
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "del": "^1.2.0",
     "gulp": "^3.8.11",
     "gulp-autoprefixer": "^2.3.0",
+    "gulp-babel": "^5.2.1",
     "gulp-combine-media-queries": "^0.2.0",
     "gulp-concat": "^2.5.2",
     "gulp-imagemin": "^2.2.1",


### PR DESCRIPTION
@vicegold suggested a pull request to merge the fix https://github.com/cromosom/gulp-boilerplate/commit/f552e3e392394723e5732949fbd4d338a1706f65 into the main branche. To bring a new feature to the table I added gulp-babel to the scripts.js.

babel.js is an EcmaScript6 transpiler and allows you to write fun stuff like:
```javascript
let animal = (pet, sound) =>
  console.log(`If you see your ${pet} it will ${sound}`);

animal('dog', 'bark');
```
without crashing older browsers